### PR TITLE
ability to run the function with mocks in test case configuration view

### DIFF
--- a/identity-server/backend/utils/getServerUrl.js
+++ b/identity-server/backend/utils/getServerUrl.js
@@ -2,9 +2,10 @@
 import * as userSettingsLoader from "../entities/UserSetting/loader.js";
 
 export const getServerUrl = async () => {
-    let serverURL = "http:localhost";
+    let serverURL = "http://localhost";
     const userSettings = await userSettingsLoader.getSettings();
     serverURL = `${serverURL}:${userSettings.server_port}`
+    return serverURL;
 }
 
 export const getServerRestApiUrl = async () => {

--- a/identity-server/frontend/src/entities/TestCase/components/ConfigureTestCase.tsx
+++ b/identity-server/frontend/src/entities/TestCase/components/ConfigureTestCase.tsx
@@ -1,13 +1,15 @@
 import {
   Box,
+  Button,
   Grid,
   IconButton,
   Modal,
   ToggleButton,
   ToggleButtonGroup,
   Typography,
+  useTheme,
 } from "@mui/material";
-import { CloseSharp } from "@mui/icons-material";
+import { CloseSharp, ErrorSharp } from "@mui/icons-material";
 import { NestedObjectTestConfigView } from "./NestedObjectTestConfigViews";
 import { useState } from "react";
 import { HorizontalFlowDiagram } from "../../../components/FlowChart/HorizontalFlowDiagram.tsx";
@@ -43,6 +45,7 @@ export const TestConfigColumns: React.FC<{
 const TestConfigViews: React.FC<{
   config: FunctionTestConfig;
 }> = ({ config }) => {
+  const theme = useTheme();
   const [diagramType, setDiagramType] = useState("vertical");
 
   const [selectedFunctionEntity, setSelectedFunctionEntity] = useState<
@@ -54,7 +57,7 @@ const TestConfigViews: React.FC<{
   };
 
   const onEntityClick = (e: DiagramEntity) => {
-    setSelectedFunctionEntity(e.metaData?.function);
+    setSelectedFunctionEntity(e.metaData?.config);
   };
   return (
     <Grid container>
@@ -79,6 +82,45 @@ const TestConfigViews: React.FC<{
       <Grid item xs={12}>
         {diagramType === "horizontal" && (
           <HorizontalFlowDiagram
+            DiagramNodeComponent={({ entity }) => {
+              const config: FunctionTestConfig = entity.metaData!.config;
+              return (
+                <Button
+                  sx={{
+                    p: 1,
+                    borderRadius: 4,
+                    border: "1px solid black",
+                    display: "flex",
+                    alignItems: "center",
+                    textTransform: "none",
+                    color: "black",
+                    background: config.functionMeta?.executedSuccessfully
+                      ? "transparent"
+                      : theme.palette.error.light,
+                  }}
+                  onClick={() => onEntityClick(entity)}
+                >
+                  {!config.functionMeta?.executedSuccessfully ? (
+                    <ErrorSharp
+                      sx={{ color: theme.palette.error.contrastText }}
+                    />
+                  ) : null}
+                  <Typography
+                    sx={{
+                      color: !config.functionMeta?.executedSuccessfully
+                        ? theme.palette.error.contrastText
+                        : undefined,
+                      ml: 1,
+                    }}
+                  >
+                    {entity.label}
+                    <Typography fontWeight={"bold"}>
+                      {entity.metaData?.function?.isMocked ? " (Mocked)" : ""}
+                    </Typography>
+                  </Typography>
+                </Button>
+              );
+            }}
             entities={[
               getDiagramEntityFromExecutedFunction(config, onEntityClick),
             ]}
@@ -86,6 +128,45 @@ const TestConfigViews: React.FC<{
         )}
         {diagramType === "vertical" && (
           <PyramidFlowDiagram
+            DiagramNodeComponent={({ entity }) => {
+              const config: FunctionTestConfig = entity.metaData!.config;
+              return (
+                <Button
+                  sx={{
+                    p: 1,
+                    borderRadius: 4,
+                    border: "1px solid black",
+                    display: "flex",
+                    alignItems: "center",
+                    textTransform: "none",
+                    color: "black",
+                    background: config.functionMeta?.executedSuccessfully
+                      ? "transparent"
+                      : theme.palette.error.light,
+                  }}
+                  onClick={() => onEntityClick(entity)}
+                >
+                  {!config.functionMeta?.executedSuccessfully ? (
+                    <ErrorSharp
+                      sx={{ color: theme.palette.error.contrastText }}
+                    />
+                  ) : null}
+                  <Typography
+                    sx={{
+                      color: !config.functionMeta?.executedSuccessfully
+                        ? theme.palette.error.contrastText
+                        : undefined,
+                      ml: 1,
+                    }}
+                  >
+                    {entity.label}
+                    <Typography fontWeight={"bold"}>
+                      {entity.metaData?.function?.isMocked ? " (Mocked)" : ""}
+                    </Typography>
+                  </Typography>
+                </Button>
+              );
+            }}
             entities={[
               getDiagramEntityFromExecutedFunction(config, onEntityClick),
             ]}
@@ -142,7 +223,7 @@ const getDiagramEntityFromExecutedFunction = (
     label: func.functionMeta.name,
     type: "node",
     metaData: {
-      function: func,
+      config: func,
     },
     onClick,
     children: [],

--- a/identity-server/frontend/src/entities/TestCase/components/NestedObjectTestConfigViews.tsx
+++ b/identity-server/frontend/src/entities/TestCase/components/NestedObjectTestConfigViews.tsx
@@ -82,8 +82,10 @@ const FunctionConfigView: React.FC<{
       }
       updateState({ assertions: [...config.assertions] });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [config]
   );
+
   return (
     <Grid container>
       <Grid item xs={12} display={"flex"} alignItems={"center"}>
@@ -155,9 +157,8 @@ const AssertionView: React.FC<{
 }> = ({ assertion, onDelete, config }) => {
   const updateState = useObjectChange(assertion);
 
-  
   useObjectChange(config, (obj) => [obj.functionMeta.input]);
-  console.log("re rendering")
+  console.log("re rendering");
 
   return (
     <Accordion>

--- a/identity-server/frontend/src/entities/TestCase/types.ts
+++ b/identity-server/frontend/src/entities/TestCase/types.ts
@@ -46,10 +46,12 @@ export type TestCaseForFunction = {
   id: string;
   inputToPass: any;
   name: string;
-  mocks: {
-    [functionName: string]: FunctionMockConfig;
-  };
+  mocks: TestCaseMocks;
   config: FunctionTestConfig;
+};
+
+export type TestCaseMocks = {
+  [functionName: string]: FunctionMockConfig;
 };
 
 export type FunctionMockConfig = {

--- a/identity-server/frontend/src/entities/TestCase/utils/getFunctionTestConfigForExecutedFunction.ts
+++ b/identity-server/frontend/src/entities/TestCase/utils/getFunctionTestConfigForExecutedFunction.ts
@@ -2,11 +2,10 @@ import { ExecutedFunction } from "../../FunctionExecution/types";
 import { FunctionTestConfig, FunctionTestConfigAssertion } from "../types";
 
 type FunctionTestConfigContext = {
-    functionCallCountMap: {
-      [key: string]: number;
-    };
+  functionCallCountMap: {
+    [key: string]: number;
   };
-  
+};
 
 export const getFunctionTestConfigForExecutedFunction = (
   f: ExecutedFunction,
@@ -20,6 +19,21 @@ export const getFunctionTestConfigForExecutedFunction = (
   context.functionCallCountMap[functionKey]++;
   const assertions: FunctionTestConfigAssertion[] = [];
 
+  if (f.executionContext.is_mocked) {
+    return {
+      _type: "FunctionTestConfig",
+      _version: 1,
+      assertions: [],
+      children: [],
+      functionCallCount: context.functionCallCountMap[functionKey],
+      functionMeta: f,
+      isRootFunction,
+      isMocked: true,
+      mockedErrorMessage: f.error,
+      mockedOutput: f.output,
+      shouldThrowError: !!f.error,
+    };
+  }
   if (f.error) {
     assertions.push({
       name: "Assert Error Message",

--- a/identity-server/frontend/src/entities/TestRun/components/NestedObjectTestResultView.tsx
+++ b/identity-server/frontend/src/entities/TestRun/components/NestedObjectTestResultView.tsx
@@ -37,7 +37,9 @@ export const TestResultFunctionView: React.FC<{
           <Typography variant="h5">{resultObject.name}</Typography>
 
           <Box sx={{ ml: 1 }}>
-            {resultObject.successful ? (
+            {resultObject.isMocked ? (
+              <Chip label="Mocked" color="info" size="small" />
+            ) : resultObject.successful ? (
               <Chip label="Passed" color="success" size="small" />
             ) : (
               <Chip label="Failed" color="error" size="small" />
@@ -76,35 +78,52 @@ export const TestResultSuccessView: React.FC<{ object: GenericTestResult }> = ({
 }) => {
   return (
     <>
-      <Grid
-        xs={12}
-        display={"flex"}
-        alignItems={"center"}
-        justifyContent={"flex-start"}
-      >
-        <Typography variant="subtitle1">Result:</Typography>
-        <Typography sx={{ ml: 1 }} variant="body1" color={"green"}>
-          Successfully matched with config
-        </Typography>
-      </Grid>
+      {object.isMocked ? (
+        <>
+          <Grid xs={12}>
+            <Accordion>
+              <AccordionSummary expandIcon={<KeyboardArrowDownSharp />}>
+                Mocked Output
+              </AccordionSummary>
+              <AccordionDetails>
+                <GeneralObjectView sourceObject={object.mockedOutput} name="" />
+              </AccordionDetails>
+            </Accordion>
+          </Grid>
+        </>
+      ) : (
+        <>
+          <Grid
+            xs={12}
+            display={"flex"}
+            alignItems={"center"}
+            justifyContent={"flex-start"}
+          >
+            <Typography variant="subtitle1">Result:</Typography>
+            <Typography sx={{ ml: 1 }} variant="body1" color={"green"}>
+              Successfully matched with config
+            </Typography>
+          </Grid>
 
-      <Grid
-        xs={12}
-        display={"flex"}
-        alignItems={"center"}
-        justifyContent={"flex-start"}
-      >
-        {object.executedSuccessfully && (
-          <Typography variant="body1" color={"green"}>
-            Function successfully executed.
-          </Typography>
-        )}
-      </Grid>
-      <Grid item xs={12} sx={{ my: 2 }}>
-        {object.assertions.map((a) => (
-          <AssertionSuccessView assertion={a} />
-        ))}
-      </Grid>
+          <Grid
+            xs={12}
+            display={"flex"}
+            alignItems={"center"}
+            justifyContent={"flex-start"}
+          >
+            {object.executedSuccessfully && (
+              <Typography variant="body1" color={"green"}>
+                Function successfully executed.
+              </Typography>
+            )}
+          </Grid>
+          <Grid item xs={12} sx={{ my: 2 }}>
+            {object.assertions.map((a) => (
+              <AssertionSuccessView assertion={a} />
+            ))}
+          </Grid>
+        </>
+      )}
     </>
   );
 };
@@ -514,7 +533,12 @@ const GeneralObjectDiff: React.FC<{
   const { sourceObject, targetObject } = props;
   if (Array.isArray(sourceObject) && Array.isArray(targetObject)) {
     return <ArrayDiff {...props} />;
-  } else if (sourceObject && typeof sourceObject === "object" && targetObject && typeof targetObject === "object") {
+  } else if (
+    sourceObject &&
+    typeof sourceObject === "object" &&
+    targetObject &&
+    typeof targetObject === "object"
+  ) {
     return <ObjectDiff {...props} />;
   } else {
     return <LiteralDiff {...props} />;

--- a/identity-server/frontend/src/entities/TestRun/components/TestResultView.tsx
+++ b/identity-server/frontend/src/entities/TestRun/components/TestResultView.tsx
@@ -375,9 +375,7 @@ const getDiagramEntityFromExecutedFunction = (
 ): DiagramEntity => {
   const entity: DiagramEntity = {
     id: func.id,
-    label:
-      func.name +
-      (func.executionContext.test_run?.is_mocked ? " (Mocked)" : ""),
+    label: func.name + (func.isMocked ? " (Mocked)" : ""),
     type: "node",
     metaData: {
       result: func,

--- a/identity-server/frontend/src/entities/TestRun/types.ts
+++ b/identity-server/frontend/src/entities/TestRun/types.ts
@@ -34,6 +34,8 @@ export type FunctionTestResult = BaseTestResult & {
   children: FunctionTestResult[];
   assertions: AssertionResult[];
   passedInput: any;
+  isMocked: boolean;
+  mockedOutput: any
 };
 
 export type AssertionResult = {

--- a/identity-trace-python-agent/identity_trace/matcher.py
+++ b/identity-trace-python-agent/identity_trace/matcher.py
@@ -37,7 +37,11 @@ class TestResult:
 
 
 class FunctionTestResult:
-    def __init__(self, _type, assertions, children, executedSuccessfully, executionContext, id, failureReasons, name, ignored, successful, thrownError, passedInput):
+    def __init__(
+            self, _type, assertions, children, executedSuccessfully,
+            executionContext, id, failureReasons, name, ignored, successful,
+            thrownError, passedInput, isMocked = False, mockedOutput = None
+        ):
         self._type = _type
         self.assertions = assertions
         self.children = children
@@ -50,6 +54,8 @@ class FunctionTestResult:
         self.successful = successful
         self.thrownError = thrownError
         self.passedInput = passedInput
+        self.isMocked = isMocked
+        self.mockedOutput = mockedOutput
     
     def serialize(self):
 
@@ -65,7 +71,9 @@ class FunctionTestResult:
             ignored = self.ignored,
             successful = self.successful,
             thrownError = self.thrownError,
-            passedInput = self.passedInput
+            passedInput = self.passedInput,
+            isMocked = self.isMocked,
+            mockedOutput = self.mockedOutput
         )
 
 def matchExecutionWithTestConfig(testRun: TestRunForTestSuite) -> TestResult:
@@ -113,10 +121,30 @@ def matchFunctionWithConfig(executedFunction: Optional[Dict[str, Any]], config: 
             name=config['functionMeta']['name'],
             ignored=False,
             successful=False,
-            thrownError="",
-            passedInput=None
+            thrownError=executedFunction.get("error", None),
+            passedInput=None,
         )
     
+    # if the function is mocked. return mock result
+    if config.get("isMocked", None):
+        return FunctionTestResult(
+            _type="FunctionTestResult",
+            assertions=[],
+            children=[],
+            executedSuccessfully=True,
+            executionContext={},
+            id=config['functionMeta']['id'],
+            failureReasons=None,
+            name=config['functionMeta']['name'],
+            ignored=False,
+            successful=True,
+            thrownError=executedFunction,
+            passedInput=None,
+            isMocked=True,
+            mockedOutput=executedFunction.get("output", None)
+        )
+
+
     assertionResults = []
     for assertion in config['assertions']:
         failureReasons = []

--- a/identity-trace-python-agent/identity_trace/runner.py
+++ b/identity-trace-python-agent/identity_trace/runner.py
@@ -440,7 +440,9 @@ def get_mocks_for_function(function_config, module_name, function_name, call_cou
         mocks_for_function = mocks.get(f"{module_name}:{function_name}", None)
 
         if mocks_for_function and isinstance(mocks_for_function, dict):
-            mock_value = mocks_for_function.get(str(call_count), None)
+            # Acount for integer or string keys
+            mock_value = mocks_for_function.get(
+                str(call_count), None) or mocks_for_function.get(call_count, None)
 
             if mock_value and isinstance(mock_value, dict):
                 return mock_value


### PR DESCRIPTION
Closes #46 
### Summary

When editing a test case, the user has the ability to mock a function. But they dont have the ability to update the test case expectation after mock.

### Solution

Give user the ability to run the function again with mocks defined. This way, they will get updated results from the executed functions. And then they can setup the expectation accordingly.

